### PR TITLE
anthropic v0.50.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,18 @@ requirements:
     - cached-property
     - jiter >=0.4.0,<1
 
+# ModuleNotFoundError: No module named 'respx'
+{% set ignore_tests = " --ignore=tests/api_resources" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/lib/streaming/test_messages.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/lib/test_bedrock.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/lib/test_vertex.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_client.py" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_files.py" %}
+
 test:
+  source_files:
+    - tests
+    - pyproject.toml
   imports:
     - anthropic
     - anthropic.lib
@@ -43,8 +54,11 @@ test:
     - tests
   commands:
     - pip check
+    - pytest -v {{ ignore_tests }} --ignore=tests/functional --asyncio-mode=auto
   requires:
     - pip
+    - pytest
+    - pytest-asyncio
 
 about:
   home: https://github.com/anthropics/anthropic-sdk-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
 requirements:
   host:
     - python
-    - poetry-core >=1.0.0
     - hatch-fancy-pypi-readme
     - hatchling >=1.26.3
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - poetry-core >=1.0.0
     - hatch-fancy-pypi-readme
-    - hatchling==1.26.3
+    - hatchling
     - pip
   run:
     - typing_extensions >=4.10,<5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,11 @@ requirements:
 test:
   imports:
     - anthropic
+    - anthropic.lib
+    - anthropic.types
+    - anthropic.resources
+  source_files:
+    - tests
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
 {% set name = "anthropic" %}
 {% set version = "0.50.0" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/anthropics/anthropic-sdk-python/archive/v{{ version }}.tar.gz
+  url: https://github.com/anthropics/{{ name }}-sdk-python/archive/v{{ version }}.tar.gz
   sha256: 18214331a4e679428015ce0af7fee157b112b81d4f6be105c70674c03796738b
 
 build:
@@ -20,19 +19,18 @@ requirements:
     - python
     - poetry-core >=1.0.0
     - hatch-fancy-pypi-readme
-    - hatchling
+    - hatchling==1.26.3
     - pip
   run:
     - typing_extensions >=4.10,<5
     - python
     - httpx >=0.25.0,<1
     - pydantic >=1.9.0,<3
-    - typing-extensions >=4.7,<5
+    - typing-extensions >=4.10,<5
     - anyio >=3.5.0,<5
     - distro >=1.7.0,<2
     - sniffio
     - cached-property
-    - tokenizers >=0.13.0
     - jiter >=0.4.0,<1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,20 @@ source:
   sha256: 18214331a4e679428015ce0af7fee157b112b81d4f6be105c70674c03796738b
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   number: 0
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - poetry-core >=1.0.0
     - hatch-fancy-pypi-readme
     - hatchling
     - pip
   run:
     - typing_extensions >=4.10,<5
-    - python >={{ python_min }},<4.0.0
+    - python
     - httpx >=0.25.0,<1
     - pydantic >=1.9.0,<3
     - typing-extensions >=4.7,<5
@@ -42,14 +42,19 @@ test:
     - pip check
   requires:
     - pip
-    - python {{ python_min }}
 
 about:
   home: https://github.com/anthropics/anthropic-sdk-python
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   summary: Library for accessing the anthropic API
+  description: |
+    The Anthropic Python SDK is a library for accessing the anthropic API.
+    It provides a simple and intuitive interface for making requests to the API and handling responses.
+    The SDK is designed to be easy to use and integrate into your existing Python projects.
   doc_url: https://console.anthropic.com/docs
+  dev_url: https://github.com/anthropics/anthropic-sdk-python
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,12 @@ requirements:
     - sniffio
     - cached-property
     - jiter >=0.4.0,<1
-
+  run_constrained:
+    - google-auth >=2,<3
+    # From google-auth[requests]
+    - requests >=2.20.0,<3.0.0
+    - boto3 >=1.28.57
+    - botocore >=1.31.57
 # ModuleNotFoundError: No module named 'respx'
 {% set ignore_tests = " --ignore=tests/api_resources" %}
 {% set ignore_tests = ignore_tests + " --ignore=tests/lib/streaming/test_messages.py" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - anyio >=3.5.0,<5
     - distro >=1.7.0,<2
     - sniffio
-    - cached-property
     - jiter >=0.4.0,<1
   run_constrained:
     - google-auth >=2,<3
@@ -37,6 +36,7 @@ requirements:
     - requests >=2.20.0,<3.0.0
     - boto3 >=1.28.57
     - botocore >=1.31.57
+
 # ModuleNotFoundError: No module named 'respx'
 {% set ignore_tests = " --ignore=tests/api_resources" %}
 {% set ignore_tests = ignore_tests + " --ignore=tests/lib/streaming/test_messages.py" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - poetry-core >=1.0.0
     - hatch-fancy-pypi-readme
-    - hatchling
+    - hatchling >=1.26.3
     - pip
   run:
     - typing_extensions >=4.10,<5


### PR DESCRIPTION
> ## ☆ anthropic v0.50.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7934)
[Upstream](https://github.com/anthropics/anthropic-sdk-python/tree/v0.50.0)
>
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host`
> * Added skip to python versions less than 3.8
> * Updated `about` section
> * Additional testing


